### PR TITLE
Make setCharHeight not explode when program is long

### DIFF
--- a/display/src/main/scala/scalera/moonrover/display/SimulatorRender.scala
+++ b/display/src/main/scala/scalera/moonrover/display/SimulatorRender.scala
@@ -151,7 +151,9 @@ object SimulatorRender {
     val height = (3 to 18)
       .reverseMap(n => n -> ((n + 4) * lines))
       .filter(_._2 < maxHeight)
-      .head._1
+      .map(_._1)
+      .headOption
+      .getOrElse(3)
     synchronized(charSize = Some(height))
     height
   }


### PR DESCRIPTION
Calling `head` directly is not type safe and thus render the simulator unusable for programs over 18 lines.
